### PR TITLE
DogVetPreferences - Introduce dog_vet_preferences

### DIFF
--- a/migrations/V7__dogs_fk_user_alterations.sql
+++ b/migrations/V7__dogs_fk_user_alterations.sql
@@ -1,0 +1,8 @@
+ALTER TABLE dogs
+ALTER COLUMN user_id DROP NOT NULL;
+
+ALTER TABLE dogs
+DROP CONSTRAINT dogs_fk_users;
+
+ALTER TABLE dogs
+ADD CONSTRAINT dogs_fk_users FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE SET NULL

--- a/migrations/V8__dog_vet_preferences.sql
+++ b/migrations/V8__dog_vet_preferences.sql
@@ -1,0 +1,10 @@
+CREATE TABLE dog_vet_preferences (
+  dog_id BIGINT NOT NULL,
+  vet_id BIGINT NOT NULL,
+  user_id BIGINT NOT NULL,
+  preference_creation_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT dog_vet_preferences_fk_dogs FOREIGN KEY (dog_id) REFERENCES dogs (dog_id) ON DELETE CASCADE,
+  CONSTRAINT dog_vet_preferences_fk_vets FOREIGN KEY (vet_id) REFERENCES vets (vet_id) ON DELETE CASCADE,
+  CONSTRAINT dog_vet_preferences_fk_users FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE,
+  CONSTRAINT dog_vet_preferences_pk PRIMARY KEY (dog_id, vet_id)
+);


### PR DESCRIPTION
Changes

(1) `dogs.user_id` is altered to be nullable and the FK constraint to the users table is configured to be ON DELETE SET NULL. This way, dog records can remain in the database when a user is deleted.

(2) A `dog_vet_preferences` table is introduced to the schema. This has a three-way relation with dogs, vets, and also users. The reason for the relation to user is so that the preference record can be deleted upon deletion of a user record—because as noted in (1) above, the deletion of a user does not cascade to associated dog records.

