### PR TITLE
Add dog_did_donate_blood column to reports table

### DIFF
--- a/migrations/V27__remove_star_from_latest_values_view.sql
+++ b/migrations/V27__remove_star_from_latest_values_view.sql
@@ -1,4 +1,4 @@
-CREATE VIEW latest_values AS (
+CREATE OR REPLACE VIEW latest_values AS (
     WITH
     mLatestReports as (
         SELECT

--- a/migrations/V28__dog_did_donate_blood.sql
+++ b/migrations/V28__dog_did_donate_blood.sql
@@ -1,0 +1,7 @@
+-- Add the new column and set the value to FALSE for all existing rows
+ALTER TABLE reports
+ADD COLUMN dog_did_donate_blood BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Drop the default value
+ALTER TABLE reports
+ALTER COLUMN dog_did_donate_blood DROP DEFAULT;

--- a/schema/V2__ref_tables.sql
+++ b/schema/V2__ref_tables.sql
@@ -112,7 +112,7 @@ CREATE TABLE reports (
   ineligibility_expiry_time TIMESTAMP WITH TIME ZONE,
   dog_id BIGINT NOT NULL,
   vet_id BIGINT NOT NULL,
-  dog_did_donate_blood BOOLEAN,
+  dog_did_donate_blood BOOLEAN NOT NULL,
   CONSTRAINT reports_fk_calls FOREIGN KEY (call_id) REFERENCES calls (call_id) ON DELETE RESTRICT,
   CONSTRAINT reports_fk_dogs FOREIGN KEY (dog_id) REFERENCES dogs (dog_id) ON DELETE RESTRICT,
   CONSTRAINT reports_fk_vets FOREIGN KEY (vet_id) REFERENCES vets (vet_id) ON DELETE RESTRICT,

--- a/schema/V2__ref_tables.sql
+++ b/schema/V2__ref_tables.sql
@@ -112,6 +112,7 @@ CREATE TABLE reports (
   ineligibility_expiry_time TIMESTAMP WITH TIME ZONE,
   dog_id BIGINT NOT NULL,
   vet_id BIGINT NOT NULL,
+  dog_did_donate_blood BOOLEAN,
   CONSTRAINT reports_fk_calls FOREIGN KEY (call_id) REFERENCES calls (call_id) ON DELETE RESTRICT,
   CONSTRAINT reports_fk_dogs FOREIGN KEY (dog_id) REFERENCES dogs (dog_id) ON DELETE RESTRICT,
   CONSTRAINT reports_fk_vets FOREIGN KEY (vet_id) REFERENCES vets (vet_id) ON DELETE RESTRICT,


### PR DESCRIPTION
Add a `dog_did_donate_blood BOOLEAN NOT NULL` column to the reports table for recording when dogs did donate blood during their appointments.

It was necessary to update the latest_values view because previously it used `tReport.*`—which caused the newly added column to be included into the view in the reference schema, BUT NOT the migrations schema because the view in the migrations schema was created before the `dog_did_donate_blood` column existed.