### PR TITLE
Impl a test-migrations GitHub workflow to verify migrations

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -20,6 +20,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Update apt
+        run: sudo apt-get update
       - name: Install Postgres 15
         run: sudo apt-get install -y postgresql-15
       - name: Install Flyway
@@ -55,6 +57,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Update apt
+        run: sudo apt-get update
       - name: Install Postgres 15
         run: sudo apt-get install -y postgresql-15
       - name: Install Flyway

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update apt
         run: sudo apt-get update
-      - name: Install Postgres 15
-        run: sudo apt-get install -y postgresql-15
+      - name: Install Postgres Client
+        run: sudo apt-get install -y postgresql-client
       - name: Install Flyway
         run: |
           sudo apt-get -y install wget
@@ -59,8 +59,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Update apt
         run: sudo apt-get update
-      - name: Install Postgres 15
-        run: sudo apt-get install -y postgresql-15
+      - name: Install Postgres Client
+        run: sudo apt-get install -y postgresql-client
       - name: Install Flyway
         run: |
           sudo apt-get -y install wget

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -20,8 +20,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - name: Install Postgres Client
-        run: sudo apt-get install -y postgresql-client-15
+      - name: Install Postgres 15
+        run: sudo apt-get install -y postgresql-15
       - name: Install Flyway
         run: |
           sudo apt-get -y install wget
@@ -55,8 +55,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - name: Install Postgres Client
-        run: sudo apt-get install -y postgresql-client-15
+      - name: Install Postgres 15
+        run: sudo apt-get install -y postgresql-15
       - name: Install Flyway
         run: |
           sudo apt-get -y install wget

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -1,0 +1,99 @@
+name: test-migrations
+run-name: ${{github.actor}} is testing migrations
+on:
+  pull_request:
+jobs:
+  # TODO: Move this into a template / called workflow?
+  dump-schema:
+    # Run on the postgres image for access to pg_dump
+    runs-on: postgres:15.2
+    env:
+      MIGRATIONS_DIR: schema
+    services:
+      postgres:
+        image: postgres:15.2
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Flyway
+        run: |
+          apt-get update
+          apt-get -y install wget
+          wget -qO- https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/10.2.0/flyway-commandline-10.2.0-linux-x64.tar.gz | tar -xvz
+          ln -s $(pwd)/flyway-10.2.0/flyway /usr/local/bin
+      - name: Run Flyway
+        run: flyway -url=jdbc:postgresql://localhost:5432/testdb -locations=${MIGRATIONS_DIR} -user=postgres -password=password -driver=org.postgresql.Driver -encoding=UTF-8 -validateOnMigrate=true -baselineOnMigrate=true -table=schema_history migrate
+      - name: Dump Postgres Database
+        run: PGPASSWORD=password pg_dump -h localhost -U postgres testdb > pg_dump.sql
+      - name: Remove migration related lines
+        run: cat pg_dump.sql | grep -v 'V[0-9.]\{1,\}__' > pg_dump_${MIGRATIONS_DIR}.sql
+      - name: Upload pg_dump_${{env.MIGRATIONS_DIR}}.sql
+        uses: actions/upload-artifact@v4
+        with:
+          name: pg_dump_${{env.MIGRATIONS_DIR}}
+          path: pg_dump_${{env.MIGRATIONS_DIR}}.sql
+
+  dump-migrations:
+    # Run on the postgres image for access to pg_dump
+    runs-on: postgres:15.2
+    env:
+      MIGRATIONS_DIR: migrations
+    services:
+      postgres:
+        image: postgres:15.2
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Flyway
+        run: |
+          apt-get update
+          apt-get -y install wget
+          wget -qO- https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/10.2.0/flyway-commandline-10.2.0-linux-x64.tar.gz | tar -xvz
+          ln -s $(pwd)/flyway-10.2.0/flyway /usr/local/bin
+      - name: Run Flyway
+        run: flyway -url=jdbc:postgresql://localhost:5432/testdb -locations=${MIGRATIONS_DIR} -user=postgres -password=password -driver=org.postgresql.Driver -encoding=UTF-8 -validateOnMigrate=true -baselineOnMigrate=true -table=schema_history migrate
+      - name: Dump Postgres Database
+        run: PGPASSWORD=password pg_dump -h localhost -U postgres testdb > pg_dump.sql
+      - name: Remove migration related lines
+        run: cat pg_dump.sql | grep -v 'V[0-9.]\{1,\}__' > pg_dump_${MIGRATIONS_DIR}.sql
+      - name: Upload pg_dump_${{env.MIGRATIONS_DIR}}.sql
+        uses: actions/upload-artifact@v4
+        with:
+          name: pg_dump_${{env.MIGRATIONS_DIR}}
+          path: pg_dump_${{env.MIGRATIONS_DIR}}.sql
+
+  compare-dumps:
+    runs-on: ubuntu:latest
+    needs: [dump-schema, dump-migrations]
+    steps:
+      - name: Download schema dump
+        uses: actions/download-artifact@v4
+        with:
+          name: pg_dump_schema
+      - name: Download migrations dump
+        uses: actions/download-artifact@v4
+        with:
+          name: pg_dump_migrations
+      - name: Compare dumps
+        run: diff pg_dump_schema.sql pg_dump_migrations.sql
+
+# ________________________________________
+# REFERENCES
+#
+# Ref1: Flyway - https://documentation.red-gate.com/fd/command-line-184127404.html
+# Ref2: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+# Ref3: Passing params between jobs - https://adamcowley.co.uk/posts/til-github-action-output-parameters/
+# Ref4: Passing files between jobs - https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow
+#

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   # TODO: Move this into a template / called workflow?
   dump-schema:
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
     env:
       MIGRATIONS_DIR: schema
     services:
@@ -42,7 +42,7 @@ jobs:
           path: pg_dump_${{env.MIGRATIONS_DIR}}.sql
 
   dump-migrations:
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
     env:
       MIGRATIONS_DIR: migrations
     services:
@@ -79,7 +79,7 @@ jobs:
           path: pg_dump_${{env.MIGRATIONS_DIR}}.sql
 
   compare-dumps:
-    runs-on: ubuntu:latest
+    runs-on: ubuntu-latest
     needs: [dump-schema, dump-migrations]
     steps:
       - name: Download schema dump

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -5,8 +5,7 @@ on:
 jobs:
   # TODO: Move this into a template / called workflow?
   dump-schema:
-    # Run on the postgres image for access to pg_dump
-    runs-on: postgres:15.2
+    runs-on: ubuntu:latest
     env:
       MIGRATIONS_DIR: schema
     services:
@@ -21,9 +20,12 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Update apt
+        run: apt-get update
+      - name: Install Postgres Client
+        run: apt-get install -y postgresql-client
       - name: Install Flyway
         run: |
-          apt-get update
           apt-get -y install wget
           wget -qO- https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/10.2.0/flyway-commandline-10.2.0-linux-x64.tar.gz | tar -xvz
           ln -s $(pwd)/flyway-10.2.0/flyway /usr/local/bin
@@ -40,8 +42,7 @@ jobs:
           path: pg_dump_${{env.MIGRATIONS_DIR}}.sql
 
   dump-migrations:
-    # Run on the postgres image for access to pg_dump
-    runs-on: postgres:15.2
+    runs-on: ubuntu:latest
     env:
       MIGRATIONS_DIR: migrations
     services:
@@ -56,9 +57,12 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Update apt
+        run: apt-get update
+      - name: Install Postgres Client
+        run: apt-get install -y postgresql-client
       - name: Install Flyway
         run: |
-          apt-get update
           apt-get -y install wget
           wget -qO- https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/10.2.0/flyway-commandline-10.2.0-linux-x64.tar.gz | tar -xvz
           ln -s $(pwd)/flyway-10.2.0/flyway /usr/local/bin

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -10,7 +10,7 @@ jobs:
       MIGRATIONS_DIR: schema
     services:
       postgres:
-        image: postgres:15.2
+        image: postgres:14.11
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -47,7 +47,7 @@ jobs:
       MIGRATIONS_DIR: migrations
     services:
       postgres:
-        image: postgres:15.2
+        image: postgres:14.11
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -20,13 +20,11 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - name: Update apt
-        run: apt-get update
       - name: Install Postgres Client
-        run: apt-get install -y postgresql-client
+        run: sudo apt-get install -y postgresql-client
       - name: Install Flyway
         run: |
-          apt-get -y install wget
+          sudo apt-get -y install wget
           wget -qO- https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/10.2.0/flyway-commandline-10.2.0-linux-x64.tar.gz | tar -xvz
           ln -s $(pwd)/flyway-10.2.0/flyway /usr/local/bin
       - name: Run Flyway
@@ -57,13 +55,11 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - name: Update apt
-        run: apt-get update
       - name: Install Postgres Client
-        run: apt-get install -y postgresql-client
+        run: sudo apt-get install -y postgresql-client
       - name: Install Flyway
         run: |
-          apt-get -y install wget
+          sudo apt-get -y install wget
           wget -qO- https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/10.2.0/flyway-commandline-10.2.0-linux-x64.tar.gz | tar -xvz
           ln -s $(pwd)/flyway-10.2.0/flyway /usr/local/bin
       - name: Run Flyway

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Postgres Client
-        run: sudo apt-get install -y postgresql-client
+        run: sudo apt-get install -y postgresql-client-15
       - name: Install Flyway
         run: |
           sudo apt-get -y install wget
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Postgres Client
-        run: sudo apt-get install -y postgresql-client
+        run: sudo apt-get install -y postgresql-client-15
       - name: Install Flyway
         run: |
           sudo apt-get -y install wget


### PR DESCRIPTION
(1) A GitHub Workflow was implemented to verify that running the migrations will lead to the desired schema.

(2) Note: Typically we've been using Postgres 15.2. However, in this workflow Postgres 14.11 is used. We do this so that the `pg_dump` command can work with the service. The command comes from postgresql-client from ubuntu-latest. Currently this is for Postgres 14.11.

(3) Note: There are two jobs—(i) dump-schema and (ii) dump-migrations—that are identical copies of each other, just parameterised differently by a `MIGRATIONS_DIR` env variable. It would be nice if this can be a template of sorts that gets called.
