### PR TITLE
Use matrix feature to make test-migrations more concise

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -10,6 +10,7 @@ jobs:
       MIGRATIONS_DIR: schema
     services:
       postgres:
+        # 27 Apr 2024 - The ubuntu-latest postgresql-client expects a 14.11 server
         image: postgres:14.11
         env:
           POSTGRES_USER: postgres
@@ -47,6 +48,7 @@ jobs:
       MIGRATIONS_DIR: migrations
     services:
       postgres:
+        # 27 Apr 2024 - The ubuntu-latest postgresql-client expects a 14.11 server
         image: postgres:14.11
         env:
           POSTGRES_USER: postgres

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -3,49 +3,13 @@ run-name: ${{github.actor}} is testing migrations
 on:
   pull_request:
 jobs:
-  # TODO: Move this into a template / called workflow?
-  dump-schema:
+  get-dumps:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        migrations_dir: [schema, migrations]
     env:
-      MIGRATIONS_DIR: schema
-    services:
-      postgres:
-        # 27 Apr 2024 - The ubuntu-latest postgresql-client expects a 14.11 server
-        image: postgres:14.11
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: testdb
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-    steps:
-      - uses: actions/checkout@v4
-      - name: Update apt
-        run: sudo apt-get update
-      - name: Install Postgres Client
-        run: sudo apt-get install -y postgresql-client
-      - name: Install Flyway
-        run: |
-          sudo apt-get -y install wget
-          wget -qO- https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/10.2.0/flyway-commandline-10.2.0-linux-x64.tar.gz | tar -xvz
-          ln -s $(pwd)/flyway-10.2.0/flyway /usr/local/bin
-      - name: Run Flyway
-        run: flyway -url=jdbc:postgresql://localhost:5432/testdb -locations=${MIGRATIONS_DIR} -user=postgres -password=password -driver=org.postgresql.Driver -encoding=UTF-8 -validateOnMigrate=true -baselineOnMigrate=true -table=schema_history migrate
-      - name: Dump Postgres Database
-        run: PGPASSWORD=password pg_dump -h localhost -U postgres testdb > pg_dump.sql
-      - name: Remove migration related lines
-        run: cat pg_dump.sql | grep -v 'V[0-9.]\{1,\}__' > pg_dump_${MIGRATIONS_DIR}.sql
-      - name: Upload pg_dump_${{env.MIGRATIONS_DIR}}.sql
-        uses: actions/upload-artifact@v4
-        with:
-          name: pg_dump_${{env.MIGRATIONS_DIR}}
-          path: pg_dump_${{env.MIGRATIONS_DIR}}.sql
-
-  dump-migrations:
-    runs-on: ubuntu-latest
-    env:
-      MIGRATIONS_DIR: migrations
+      MIGRATIONS_DIR: ${{matrix.migrations_dir}}
     services:
       postgres:
         # 27 Apr 2024 - The ubuntu-latest postgresql-client expects a 14.11 server
@@ -82,7 +46,7 @@ jobs:
 
   compare-dumps:
     runs-on: ubuntu-latest
-    needs: [dump-schema, dump-migrations]
+    needs: [get-dumps]
     steps:
       - name: Download schema dump
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   get-dumps:
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
     strategy:
       matrix:
         migrations_dir: [schema, migrations]


### PR DESCRIPTION
(1) This commit solve the duplicate dump-schema and dump-migrations problem.

(2) It uses test matrix - https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs

(3) The matrix value is supplied to `MIGRATIONS_DIR`. That's it!
