### PR TITLE
GitHub workflows to run migrations against the dev database

### DIFF
--- a/.github/workflows/migrate-dev.yml
+++ b/.github/workflows/migrate-dev.yml
@@ -11,7 +11,12 @@ jobs:
     uses: ./.github/workflows/test-migrations.yml
   run-migrations:
     needs: [test-migrations]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Hello
-        run: echo "Hello"
+    uses: ./.github/workflows/run-migrations.yml
+    with:
+      migrations_dir: migrations
+    secrets:
+      DB_HOST: ${{secrets.DEV_DB_HOST}}
+      DB_PORT: ${{secrets.DEV_DB_PORT}}
+      DB_USER: ${{secrets.DEV_DB_USER}}
+      DB_PASSWORD: ${{secrets.DEV_DB_PASSWORD}}
+      DB_NAME: ${{secrets.DEV_DB_NAME}}

--- a/.github/workflows/migrate-dev.yml
+++ b/.github/workflows/migrate-dev.yml
@@ -1,11 +1,10 @@
 # Ref1: https://docs.github.com/en/actions/using-workflows/reusing-workflows
 name: migrate-dev
-run-name: ${{github.actor}} is developing the workfolw for running migrations against the dev database
+run-name: ${{github.actor}} is pushing migrations to dev
 on:
   push:
     branches:
       - main
-      - deploy-dev
 jobs:
   test:
     uses: ./.github/workflows/test-migrations.yml

--- a/.github/workflows/migrate-dev.yml
+++ b/.github/workflows/migrate-dev.yml
@@ -1,0 +1,10 @@
+# Ref1: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+name: migrate-dev
+on:
+  push:
+    branches:
+      - main
+      - deploy-dev
+jobs:
+  call-test-migrations:
+    uses: ./.github/workflows/test-migrations.yml

--- a/.github/workflows/migrate-dev.yml
+++ b/.github/workflows/migrate-dev.yml
@@ -1,10 +1,17 @@
 # Ref1: https://docs.github.com/en/actions/using-workflows/reusing-workflows
 name: migrate-dev
+run-name: ${{github.actor}} is developing the workfolw for running migrations against the dev database
 on:
   push:
     branches:
       - main
       - deploy-dev
 jobs:
-  call-test-migrations:
+  test-migrations:
     uses: ./.github/workflows/test-migrations.yml
+  run-migrations:
+    needs: [test-migrations]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hello
+        run: echo "Hello"

--- a/.github/workflows/migrate-dev.yml
+++ b/.github/workflows/migrate-dev.yml
@@ -7,10 +7,10 @@ on:
       - main
       - deploy-dev
 jobs:
-  test-migrations:
+  test:
     uses: ./.github/workflows/test-migrations.yml
-  run-migrations:
-    needs: [test-migrations]
+  migrate:
+    needs: [test]
     uses: ./.github/workflows/run-migrations.yml
     with:
       migrations_dir: migrations

--- a/.github/workflows/run-migrations.yml
+++ b/.github/workflows/run-migrations.yml
@@ -1,0 +1,40 @@
+# Reusable Workflow
+name: run-migrations
+on:
+  workflow_call:
+    inputs:
+      migrations_dir:
+        required: true
+        type: string
+    secrets:
+      DB_HOST:
+        required: true
+      DB_PORT:
+        required: true
+      DB_USER:
+        required: true
+      DB_PASSWORD:
+        required: true
+      DB_NAME:
+        required: true
+env:
+  DB_HOST: ${{secrets.DB_HOST}}
+  DB_PORT: ${{secrets.DB_PORT}}
+  DB_USER: ${{secrets.DB_USER}}
+  DB_PASSWORD: ${{secrets.DB_PASSWORD}}
+  DB_NAME: ${{secrets.DB_NAME}}
+  MIGRATIONS_DIR: ${{inputs.migrations_dir}}
+jobs:
+  run-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update apt
+        run: sudo apt-get update
+      - name: Install Flyway
+        run: |
+          sudo apt-get -y install wget
+          wget -qO- https://download.red-gate.com/maven/release/com/redgate/flyway/flyway-commandline/10.2.0/flyway-commandline-10.2.0-linux-x64.tar.gz | tar -xvz
+          ln -s $(pwd)/flyway-10.2.0/flyway /usr/local/bin
+      - name: Run Flyway
+        run: flyway -url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME} -locations=${MIGRATIONS_DIR} -user=${DB_USER} -password=${DB_PASSWORD} migrate

--- a/.github/workflows/run-migrations.yml
+++ b/.github/workflows/run-migrations.yml
@@ -1,4 +1,5 @@
 # Reusable Workflow
+# Ref1: https://docs.github.com/en/actions/using-workflows/reusing-workflows
 name: run-migrations
 on:
   workflow_call:

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -2,6 +2,7 @@ name: test-migrations
 run-name: ${{github.actor}} is testing migrations
 on:
   pull_request:
+  workflow_call:
 jobs:
   get-dumps:
     runs-on: ubuntu-latest


### PR DESCRIPTION
(1) This commit implements GitHub workflows to run migrations against the dev database.

(2) Details

-(a) A reusable run-migrations workflow is created. This is done using on.workflow_call (Ref1).

-(b) The existing test-migrations workflow is made to be reusable.

-(c) A migrate-dev workflow is created that calls test-migrations and then run-migrations with credentials for the dev database. Later, we can add migrate-{env} for any other environment we need.

Ref1: https://docs.github.com/en/actions/using-workflows/reusing-workflows